### PR TITLE
Update Makefile

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -18,7 +18,7 @@ ifeq ($(LUA), )
 	$(error No Lua library set)
 endif
 
-DFLAGS = -w -wi -ignore -m$(MODEL) -I../ -L-L../lib -L-lluad -L-l$(LUA)
+DFLAGS = -w -wi -ignore -m$(MODEL) -I../ -L-L../lib -L-lluad-d -L-l$(LUA)
 
 ifeq ($(BUILD), release)
 	DFLAGS += -release -O -inline -noboundscheck


### PR DESCRIPTION
It seems that the built library is always called "libluad-d.a" right?   In any case, this causes the examples to build correctly on Linux and OSX.
