### PR TITLE
Add support for user defined attributes / manual overload resolution

### DIFF
--- a/luad/all.d
+++ b/luad/all.d
@@ -7,4 +7,4 @@ module luad.all;
 
 public import luad.base, luad.table, luad.lfunction, luad.dynamic, luad.state, luad.lmodule;
 
-public import luad.conversions.functions : LuaVariableReturn, variableReturn, NoScript, ScriptRename, ScriptAffix;
+public import luad.conversions.functions : LuaVariableReturn, variableReturn, noscript, rename, prefix, suffix;

--- a/luad/conversions/classes.d
+++ b/luad/conversions/classes.d
@@ -303,14 +303,15 @@ unittest
 	{
 		int n = 5;
 
-		@ScriptAffix("set")  @property void foo(int x)
+		@prefix("set")  @property void foo(int x)
 		{
 			n = x;
 		}
 
-		@ScriptRename("givefoo")  @property int foo() { return n; }
+		@rename("givefoo")  @property int foo() { return n; }
 
-		@NoScript void bar() { }
+		@noscript() @rename("shouldntExist") void bar() { }
+		@rename("shouldExist") void newbar() { }
 	}
 
 	L = luaL_newstate();
@@ -321,7 +322,10 @@ unittest
 	lua_setglobal(L, "A");
 
 	unittest_lua(L, "assert(A ~= nil)");
+	unittest_lua(L, "assert(A.shouldntExist == nil)");
+	unittest_lua(L, "assert(A.bar == nil)");
+	unittest_lua(L, "assert(A.shouldExist ~= nil)");
+	unittest_lua(L, "assert(A.newbar == nil)");
 	unittest_lua(L, "assert(A:givefoo() == 5)");
 	unittest_lua(L, "A:setfoo(10); assert(A:givefoo() == 10)");
-	unittest_lua(L, "assert(A.bar == nil)");
 }


### PR DESCRIPTION
Adds support for the following attributes on class methods:
- NoScript - Prevents the method from being registered.
- ScriptRename(newname) - Changes the method's registration name to newname (so if you had `A::foo @ScriptRename(bar)` it'd be registered as `A::bar`).
- ScriptAffix(affix, isSuffix) - Changes the method's registration name to include a prefix or suffix.

**Utility**
- Allows binding properties and other overloaded functions correctly, if the user specifies alternate function names.
- Allows the user to hide internal APIs (useful in games for example, where it might be beneficial to have access to renderer stats in Lua but without including the rest of the renderer's functions) with reduced boilerplate.

**Issues**
This still doesn't solve the base problem of registering overloaded functions and ideally pushMethod  and pushOverloadedMethod would be written with a more generic pushMethod as their base.

**Example**

``` D
class A
{
    int _x = 10;

    int x() @property
    {
        return _x;
    }

    void x(int nx) @property @ScriptAffix("Set")
    {
        _x = nx;
    }

    void sayhello() @ScriptRename("hello")
    {
        writeln("hello");
    }

    void internalfunc() @NoScript
    {
        // ...
    }
}

A a = new A();
lua["a"] = a;

// In lua code
print(a:x()) // 10
a:Setx(2)
print(a:x()) // 2
// a:sayhello()  -- error, doesn't exist
a:hello() // "hello"
// a:internalfunc() -- error, doesn't exist
```
