### PR TITLE
Fixed bug with lightuserdata functions.

### DIFF
--- a/luad/conversions/functions.d
+++ b/luad/conversions/functions.d
@@ -204,7 +204,7 @@ extern(C) int functionWrapper(T)(lua_State* L)
 		argsError(L, top, requiredArgs);
 
 	//Get function
-	static if(is(T == function))
+	static if(isFunctionPointer!T)
 		T func = cast(T)lua_touserdata(L, lua_upvalueindex(1));
 	else
 		T func = *cast(T*)lua_touserdata(L, lua_upvalueindex(1));
@@ -227,7 +227,7 @@ public:
 
 void pushFunction(T)(lua_State* L, T func) if (isSomeFunction!T)
 {
-	static if(is(T == function))
+	static if(isFunctionPointer!T)
 		lua_pushlightuserdata(L, func);
 	else
 	{


### PR DESCRIPTION
Fixed a pre-existing bug where lightuserdata was never actually used.

T is always a function pointer, but `is(T == function) == false` if T is a function pointer.
