### PR TITLE
Updates for DMD2.070 deprecations

### DIFF
--- a/luad/base.d
+++ b/luad/base.d
@@ -3,7 +3,7 @@ module luad.base;
 import luad.c.all;
 import luad.stack;
 
-import std.c.string : strlen;
+import core.stdc.string : strlen;
 
 /**
  * Enumerates all Lua types.

--- a/luad/testing.d
+++ b/luad/testing.d
@@ -3,7 +3,7 @@ module luad.testing;
 
 import luad.c.all;
 
-import std.c.string : strcmp;
+import core.stdc.string : strcmp;
 import std.string : format;
 import std.string : toStringz;
 


### PR DESCRIPTION
This addresses the deprecation messages output by dmd 2.070.0

> Deprecation: module std.c.string is deprecated - Import core.stdc.string instea
