### PR TITLE
Struct conversions with private/internal members (fix #95)

### DIFF
--- a/luad/all.d
+++ b/luad/all.d
@@ -8,3 +8,4 @@ module luad.all;
 public import luad.base, luad.table, luad.lfunction, luad.dynamic, luad.state, luad.lmodule;
 
 public import luad.conversions.functions : LuaVariableReturn, variableReturn;
+public import luad.conversions.structs : internal;

--- a/luad/conversions/structs.d
+++ b/luad/conversions/structs.d
@@ -12,10 +12,12 @@ import luad.c.all;
 
 import luad.stack;
 
+enum internal;
+
 private template isInternal(T, string field)
 {
 	import std.traits : hasUDA;
-	enum isInternal = hasUDA!(mixin("T."~field), "internal") || field.length >= 2 && field[0..2] == "__";
+	enum isInternal = hasUDA!(mixin("T."~field), internal) || field.length >= 2 && field[0..2] == "__";
 }
 
 //TODO: ignore static fields, post-blits, destructors, etc?


### PR DESCRIPTION
Related with #95

These commits makes LuaD ignore non public members, as well as members annotated with the `@internal` UDA.

``` d
struct LuaData{
  int a; //converted
  private int b; //skipped
  protected int c; //skipped
  @internal public int d; //skipped
  public int __e; //skipped using existing rules
}
```

Currently, the only way to ignore members is to prepend their names with a double underscore.
If an inaccesible member (private or package) is not ignored,  the compilation will fail with LuaD trying to access the member.
