### PR TITLE
:bug: Fix dub test missing strcmp

### DIFF
--- a/luad/stack.d
+++ b/luad/stack.d
@@ -58,6 +58,7 @@ module luad.stack;
 import std.range;
 import std.traits;
 import std.typecons;
+import core.stdc.string;
 
 import luad.c.all;
 


### PR DESCRIPTION
$ dub test

luad/stack.d(588,33): Error: undefined identifier strcmp

This is only a partial fix for the Unittest build not working. The other error I have not been able to track down the cause... I'm slightly leaning toward the attributes being assigned "pure nothrow @nogc @safe"

> luad/stack.d(183,3): Error: static assert:  "No Lua type defined for lua_State*"
luad/stack.d(224,23):        instantiated from here: luaTypeOf!(lua_State*)
luad/stack.d(378,10):        instantiated from here: getValue!(lua_State*, argumentTypeMismatch)
luad/conversions/functions.d(215,13):        instantiated from here: getArgument!(extern (C) int function(lua_State*) pure nothrow @nogc @safe, 0)
luad/conversions/functions.d(248,23):        ... (1 instantiations, -v to show) ...
luad/stack.d(133,15):        instantiated from here: pushFunction!(extern (C) int function(lua_State*) pure nothrow @nogc @safe)
luad/stack.d(626,11):        instantiated from here: pushValue!(extern (C) int function(lua_State*) pure nothrow @nogc @safe)

Rather than accepting the C function as a LuaFunction, it is trying to convert the lua_state* argument. See: #112 