### PR TITLE
Replace 'body' with 'do'

### DIFF
--- a/luad/lfunction.d
+++ b/luad/lfunction.d
@@ -86,7 +86,7 @@ struct LuaFunction
 	 */
 	void setEnvironment(ref LuaTable env)
 	in { assert(this.state == env.state); }
-	body
+	do
 	{
 		this.push();
 		env.push();

--- a/luad/table.d
+++ b/luad/table.d
@@ -187,7 +187,7 @@ struct LuaTable
  	 */
 	void setMetaTable(ref LuaTable meta) @trusted
 	in{ assert(this.state == meta.state); }
-	body
+	do
 	{
 		this.push();
 		meta.push();


### PR DESCRIPTION
The `body` keyword is deprecated.